### PR TITLE
UObjects and Session Name Updates

### DIFF
--- a/Companion/exporter/exporter.go
+++ b/Companion/exporter/exporter.go
@@ -43,7 +43,8 @@ func NewPrometheusExporter(frmApiHosts []string) *PrometheusExporter {
 		portalCollector := NewPortalCollector("/getPortal")
 		hypertubeCollector := NewHypertubeCollector("/getHyperEntrance")
 		frackingCollector := NewFrackingCollector("/getFrackingActivator")
-		collectorRunners = append(collectorRunners, NewCollectorRunner(ctx, frmApiHost, productionCollector, powerCollector, buildingCollector, vehicleCollector, trainCollector, droneCollector, vehicleStationCollector, trainStationCollector, resourceSinkCollector, pumpCollector, extractorCollector, portalCollector, hypertubeCollector, frackingCollector))
+		uobjectCollector := NewUObjectCollector("/getUObjectCount")
+		collectorRunners = append(collectorRunners, NewCollectorRunner(ctx, frmApiHost, productionCollector, powerCollector, buildingCollector, vehicleCollector, trainCollector, droneCollector, vehicleStationCollector, trainStationCollector, resourceSinkCollector, pumpCollector, extractorCollector, portalCollector, hypertubeCollector, frackingCollector, uobjectCollector))
 	}
 
 	return &PrometheusExporter{

--- a/Companion/exporter/frm_server_fake_test.go
+++ b/Companion/exporter/frm_server_fake_test.go
@@ -27,6 +27,7 @@ type FRMServerFake struct {
 	portalData               []exporter.PortalDetails
 	hypertubeData            []exporter.HypertubeDetails
 	frackingData             []exporter.FrackingDetails
+	uobjectData              exporter.UObjectDetails
 }
 
 func NewFRMServerFake() *FRMServerFake {
@@ -54,6 +55,7 @@ func NewFRMServerFake() *FRMServerFake {
 	mux.Handle("/getPortal", http.HandlerFunc(getStatsHandler(&fake.portalData)))
 	mux.Handle("/getHyperEntrance", http.HandlerFunc(getStatsHandler(&fake.hypertubeData)))
 	mux.Handle("/getFrackingActivator", http.HandlerFunc(getStatsHandler(&fake.frackingData)))
+	mux.Handle("/getUObjectCount", http.HandlerFunc(getStatsHandler(&fake.uobjectData)))
 
 	return fake
 }
@@ -138,6 +140,10 @@ func (e *FRMServerFake) ReturnsFrackingData(data []exporter.FrackingDetails) {
 
 func (e *FRMServerFake) ReturnsSessionInfoData(data exporter.SessionInfo) {
 	e.sessionInfoData = data
+}
+
+func (e *FRMServerFake) ReturnsUObjectData(data exporter.UObjectDetails) {
+	e.uobjectData = data
 }
 
 func getStatsHandler(data any) func(w http.ResponseWriter, r *http.Request) {

--- a/Companion/exporter/uobject_collector.go
+++ b/Companion/exporter/uobject_collector.go
@@ -1,0 +1,33 @@
+package exporter
+
+import (
+    "log"
+)
+
+type UObjectDetails struct {
+    UObjectCount    float64 `json:"UObjectCount"`
+    UObjectCapacity float64 `json:"UObjectCapacity"`
+}
+
+type UObjectCollector struct {
+    endpoint string
+}
+
+func NewUObjectCollector(endpoint string) *UObjectCollector {
+    return &UObjectCollector{
+        endpoint: endpoint,
+    }
+}
+
+func (c *UObjectCollector) Collect(frmAddress string, sessionName string) {
+    details := UObjectDetails{}
+    if err := retrieveData(frmAddress+c.endpoint, &details); err != nil {
+        log.Printf("error reading UObject stats from FRM: %s\n", err)
+        return
+    }
+
+    UObjectCount.WithLabelValues(frmAddress, sessionName).Set(details.UObjectCount)
+    UObjectCapacity.WithLabelValues(frmAddress, sessionName).Set(details.UObjectCapacity)
+}
+
+func (c *UObjectCollector) DropCache() {}

--- a/Companion/exporter/uobject_collector_test.go
+++ b/Companion/exporter/uobject_collector_test.go
@@ -1,0 +1,46 @@
+package exporter_test
+
+import (
+    "github.com/AP-Hunt/FicsitRemoteMonitoringCompanion/Companion/exporter"
+    . "github.com/onsi/ginkgo/v2"
+    . "github.com/onsi/gomega"
+)
+
+var _ = Describe("UObjectCollector", func() {
+    var url string
+    var sessionName = "default"
+    var collector *exporter.UObjectCollector
+
+    BeforeEach(func() {
+        FRMServer.Reset()
+        url = FRMServer.server.URL
+        collector = exporter.NewUObjectCollector("/getUObjectCount")
+
+        FRMServer.ReturnsUObjectData(exporter.UObjectDetails{
+            UObjectCount:    1234,
+            UObjectCapacity: 2000,
+        })
+    })
+
+    AfterEach(func() {
+        collector = nil
+    })
+
+    Describe("UObject metrics collection", func() {
+        It("sets uobject_count with url/session labels", func() {
+            collector.Collect(url, sessionName)
+
+            val, err := gaugeValue(exporter.UObjectCount, url, sessionName)
+            Expect(err).ToNot(HaveOccurred())
+            Expect(val).To(Equal(float64(1234)))
+        })
+
+        It("sets uobject_capacity with url/session labels", func() {
+            collector.Collect(url, sessionName)
+
+            val, err := gaugeValue(exporter.UObjectCapacity, url, sessionName)
+            Expect(err).ToNot(HaveOccurred())
+            Expect(val).To(Equal(float64(2000)))
+        })
+    })
+})

--- a/Companion/exporter/uobject_metrics.go
+++ b/Companion/exporter/uobject_metrics.go
@@ -5,7 +5,7 @@ import "github.com/prometheus/client_golang/prometheus"
 // No extra labels; RegisterNewGaugeVec adds url and session_name automatically.
 var (
     UObjectCount = RegisterNewGaugeVec(prometheus.GaugeOpts{
-        Name: "uobject_count",
+        Name: "uobjects_loaded",
         Help: "Number of UObjects currently loaded",
     }, []string{})
 

--- a/Companion/exporter/uobject_metrics.go
+++ b/Companion/exporter/uobject_metrics.go
@@ -1,0 +1,16 @@
+package exporter
+
+import "github.com/prometheus/client_golang/prometheus"
+
+// No extra labels; RegisterNewGaugeVec adds url and session_name automatically.
+var (
+    UObjectCount = RegisterNewGaugeVec(prometheus.GaugeOpts{
+        Name: "uobject_count",
+        Help: "Number of UObjects currently loaded",
+    }, []string{})
+
+    UObjectCapacity = RegisterNewGaugeVec(prometheus.GaugeOpts{
+        Name: "uobject_capacity",
+        Help: "UObject capacity limit",
+    }, []string{})
+)


### PR DESCRIPTION
This PR has ~~two changes~~ one change:

1) UObject Metrics were added: `uobject_loaded` and `uobject_capacity`. I chose `_loaded` over `_count` since prometheus reserves the `_count` suffix

- Couple notes:
  - FWIW The  `uobject_loaded` metric can be inaccurate since it uses its own uobjects to count the other uobjects. In addition, there may be some spikes caused by satisfactory's garbage collection mechanism. Downstream consumers should expect some variance (maybe 1%) between the metric and the "true" value
  - New saves start with ~380k (18%) Uobjects

~~2) Removed the regex logic in `SanitizeSessionName` function. This is a legacy feature that shouldn't really be needed since [Prometheus 3.0 (released ~2024)](https://prometheus.io/docs/guides/utf8/) supports utf8 characters in label names and values.~~ SEE BELOW